### PR TITLE
Update default configuration

### DIFF
--- a/.ebextensions/composer.config
+++ b/.ebextensions/composer.config
@@ -3,6 +3,7 @@ commands:
     command: export COMPOSER_HOME=/root && /usr/bin/composer.phar self-update
 
 option_settings:
-  - namespace: aws:elasticbeanstalk:application:environment
-    option_name: COMPOSER_HOME
-    value: /root
+  aws:elasticbeanstalk:application:environment:
+    COMPOSER_HOME: /root
+  aws:elasticbeanstalk:container:php:phpini:
+    document_root: /web


### PR DESCRIPTION
Include the document_root setting in the default configuration and convert to shorthand syntax for config option settings.
